### PR TITLE
feat: add user profile editing

### DIFF
--- a/novaflow/package.json
+++ b/novaflow/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@mantine/core": "^7.10.1",
+    "@mantine/hooks": "^7.10.1",
+    "@supabase/supabase-js": "^2.42.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/novaflow/src/features/users/ProfilePage.tsx
+++ b/novaflow/src/features/users/ProfilePage.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { Avatar, Button, FileInput, Stack, Text, TextInput } from '@mantine/core';
+import { supabase } from '../../services';
+import { useUpdateProfile } from './hooks/useUpdateProfile';
+
+const MAX_AVATAR_SIZE = 2 * 1024 * 1024; // 2MB
+const ALLOWED_TYPES = ['image/png', 'image/jpeg'];
+
+interface Profile {
+  id: string;
+  name: string;
+  avatar_url: string | null;
+}
+
+interface ProfilePageProps {
+  userId: string;
+}
+
+/**
+ * Profile page component. Allows the current user to update their name and avatar.
+ * Other workspace members get a read-only view intended for admins.
+ */
+export function ProfilePage({ userId }: ProfilePageProps) {
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const { updateProfile } = useUpdateProfile();
+
+  useEffect(() => {
+    // Fetch profile data
+    supabase
+      .from('Users')
+      .select('id, name, avatar_url')
+      .eq('id', userId)
+      .single()
+      .then(({ data, error }) => {
+        if (error) {
+          console.error('Failed to fetch profile', error);
+        } else if (data) {
+          setProfile(data);
+        }
+      });
+
+    // Determine current user
+    supabase.auth.getUser().then(({ data }) => {
+      setCurrentUserId(data.user?.id ?? null);
+    });
+  }, [userId]);
+
+  const handleAvatarChange = async (file: File | null) => {
+    if (!profile || !file) return;
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      console.error('Invalid file type');
+      return;
+    }
+    if (file.size > MAX_AVATAR_SIZE) {
+      console.error('File too large');
+      return;
+    }
+    const ext = file.name.split('.').pop();
+    const filePath = `${profile.id}.${ext}`;
+    const { error } = await supabase.storage.from('avatars').upload(filePath, file, {
+      upsert: true,
+    });
+    if (error) {
+      console.error('Avatar upload failed', error);
+      return;
+    }
+    const { data } = supabase.storage.from('avatars').getPublicUrl(filePath);
+    setProfile({ ...profile, avatar_url: data.publicUrl });
+  };
+
+  const handleSave = async () => {
+    if (!profile) return;
+    await updateProfile(profile.id, {
+      name: profile.name,
+      avatar_url: profile.avatar_url ?? undefined,
+    });
+  };
+
+  if (!profile) {
+    return <Text>Loading...</Text>;
+  }
+
+  const isCurrentUser = currentUserId === profile.id;
+
+  if (!isCurrentUser) {
+    // Read-only admin view
+    return (
+      <Stack>
+        <Avatar src={profile.avatar_url ?? undefined} size={120} />
+        <Text fw={500}>{profile.name}</Text>
+        <Text c="dimmed">Admin-only view</Text>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack>
+      <Avatar src={profile.avatar_url ?? undefined} size={120} />
+      <FileInput
+        accept={ALLOWED_TYPES.join(',')}
+        label="Avatar"
+        onChange={handleAvatarChange}
+      />
+      <TextInput
+        label="Name"
+        value={profile.name}
+        onChange={(e) => setProfile({ ...profile, name: e.currentTarget.value })}
+      />
+      <Button onClick={handleSave}>Save</Button>
+    </Stack>
+  );
+}
+
+export default ProfilePage;

--- a/novaflow/src/features/users/hooks/useUpdateProfile.ts
+++ b/novaflow/src/features/users/hooks/useUpdateProfile.ts
@@ -1,0 +1,23 @@
+import { useCallback } from 'react';
+import { supabase } from '../../../services';
+
+export interface ProfileUpdates {
+  name?: string;
+  avatar_url?: string;
+}
+
+/**
+ * Hook exposing a profile update helper.
+ * Wraps `supabase.from('Users').update` with error handling.
+ */
+export function useUpdateProfile() {
+  const updateProfile = useCallback(async (userId: string, updates: ProfileUpdates) => {
+    const { error } = await supabase.from('Users').update(updates).eq('id', userId);
+    if (error) {
+      console.error('Failed to update profile', error);
+      throw error;
+    }
+  }, []);
+
+  return { updateProfile };
+}

--- a/novaflow/src/features/users/index.ts
+++ b/novaflow/src/features/users/index.ts
@@ -1,0 +1,3 @@
+export { ProfilePage } from './ProfilePage';
+export type { ProfileUpdates } from './hooks/useUpdateProfile';
+export { useUpdateProfile } from './hooks/useUpdateProfile';

--- a/novaflow/src/services/index.ts
+++ b/novaflow/src/services/index.ts
@@ -1,7 +1,6 @@
 // API services and Supabase wrappers
 
-// Supabase client will be configured here
-// export { supabase } from './supabase';
+export { supabase } from './supabase';
 
 // Service abstractions will be implemented here
 export const apiService = {

--- a/novaflow/src/services/supabase.ts
+++ b/novaflow/src/services/supabase.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js';
+
+// Supabase client configured via environment variables.
+// These values should be defined in `.env` or similar and
+// must not be committed to the repository.
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);


### PR DESCRIPTION
## Summary
- allow users to update name and avatar from new ProfilePage
- support supabase user updates and avatar uploads
- expose useUpdateProfile hook and supabase client

## Testing
- `npm test` *(fails: Missing script "test")*
- `pnpm lint` *(fails: @typescript-eslint/no-explicit-any in src/lib/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_688fbacc09c4832b893697e59a1d0639