### PR TITLE
feat: add workspace management

### DIFF
--- a/novaflow/package.json
+++ b/novaflow/package.json
@@ -7,11 +7,14 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest",
     "preview": "vite preview"
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "@supabase/supabase-js": "^2.45.0",
+    "zustand": "^4.5.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
@@ -24,6 +27,7 @@
     "globals": "^16.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^1.6.0"
   }
 }

--- a/novaflow/src/features/workspaces/api.ts
+++ b/novaflow/src/features/workspaces/api.ts
@@ -1,0 +1,110 @@
+import { supabase } from '../../services/supabase';
+import type { Workspace } from './store';
+
+export type Role = 'admin' | 'member';
+
+export interface WorkspaceMember {
+  id: string;
+  email: string;
+  role: Role;
+}
+
+export async function fetchWorkspaces(userId: string): Promise<Workspace[]> {
+  const { data, error } = await supabase
+    .from('workspaces')
+    .select('id, name')
+    .eq('owner_id', userId);
+  if (error) throw error;
+  return (data as Workspace[]) ?? [];
+}
+
+export async function createWorkspace(
+  name: string,
+  ownerId: string,
+): Promise<Workspace> {
+  const { data, error } = await supabase
+    .from('workspaces')
+    .insert({ name, owner_id: ownerId })
+    .select('id, name')
+    .single();
+  if (error) throw error;
+  await supabase.from('workspace_members').insert({
+    workspace_id: data.id,
+    user_id: ownerId,
+    role: 'admin',
+  });
+  return data as Workspace;
+}
+
+export async function inviteMember(
+  workspaceId: string,
+  email: string,
+  role: Role,
+) {
+  const { data, error } = await supabase.auth.admin.inviteUserByEmail(email);
+  if (error) throw error;
+  const userId = data.user?.id;
+  if (!userId) throw new Error('User invitation failed');
+  await supabase.from('workspace_members').insert({
+    workspace_id: workspaceId,
+    user_id: userId,
+    role,
+  });
+}
+
+export async function listMembers(
+  workspaceId: string,
+): Promise<WorkspaceMember[]> {
+  const { data, error } = await supabase
+    .from('workspace_members')
+    .select('user_id, role, profiles(email)')
+    .eq('workspace_id', workspaceId);
+  if (error) throw error;
+  return (data || []).map((row) => ({
+    id: row.user_id,
+    email: row.profiles?.email ?? '',
+    role: row.role as Role,
+  }));
+}
+
+export async function updateMemberRole(
+  workspaceId: string,
+  userId: string,
+  role: Role,
+) {
+  const { error } = await supabase
+    .from('workspace_members')
+    .update({ role })
+    .eq('workspace_id', workspaceId)
+    .eq('user_id', userId);
+  if (error) throw error;
+}
+
+export async function removeMember(
+  workspaceId: string,
+  userId: string,
+) {
+  const { data, error } = await supabase
+    .from('workspace_members')
+    .select('role')
+    .eq('workspace_id', workspaceId)
+    .eq('user_id', userId)
+    .single();
+  if (error) throw error;
+  if (data.role === 'admin') {
+    const { data: admins } = await supabase
+      .from('workspace_members')
+      .select('user_id')
+      .eq('workspace_id', workspaceId)
+      .eq('role', 'admin');
+    if ((admins?.length ?? 0) <= 1) {
+      throw new Error('Cannot remove the last admin');
+    }
+  }
+  const { error: delError } = await supabase
+    .from('workspace_members')
+    .delete()
+    .eq('workspace_id', workspaceId)
+    .eq('user_id', userId);
+  if (delError) throw delError;
+}

--- a/novaflow/src/features/workspaces/components/MemberInviteForm.tsx
+++ b/novaflow/src/features/workspaces/components/MemberInviteForm.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { inviteMember, type Role } from '../api';
+import RoleSelector from './RoleSelector';
+
+interface Props {
+  workspaceId: string;
+  onInvited?: () => void;
+}
+
+const MemberInviteForm: React.FC<Props> = ({ workspaceId, onInvited }) => {
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState<Role>('member');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await inviteMember(workspaceId, email, role);
+      setEmail('');
+      setRole('member');
+      onInvited?.();
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        type="email"
+        placeholder="User email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <RoleSelector value={role} onChange={setRole} />
+      <button type="submit" disabled={loading}>
+        Invite
+      </button>
+    </form>
+  );
+};
+
+export default MemberInviteForm;

--- a/novaflow/src/features/workspaces/components/MemberList.tsx
+++ b/novaflow/src/features/workspaces/components/MemberList.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import {
+  listMembers,
+  updateMemberRole,
+  removeMember,
+  type WorkspaceMember,
+  type Role,
+} from '../api';
+import RoleSelector from './RoleSelector';
+
+interface Props {
+  workspaceId: string;
+}
+
+const MemberList: React.FC<Props> = ({ workspaceId }) => {
+  const [members, setMembers] = useState<WorkspaceMember[]>([]);
+
+  useEffect(() => {
+    listMembers(workspaceId)
+      .then(setMembers)
+      .catch((err) => console.error(err));
+  }, [workspaceId]);
+
+  const handleRoleChange = async (userId: string, role: Role) => {
+    try {
+      await updateMemberRole(workspaceId, userId, role);
+      setMembers((prev) => prev.map((m) => (m.id === userId ? { ...m, role } : m)));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleRemove = async (userId: string) => {
+    try {
+      await removeMember(workspaceId, userId);
+      setMembers((prev) => prev.filter((m) => m.id !== userId));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div>
+      <h3>Members</h3>
+      <ul>
+        {members.map((m) => (
+          <li key={m.id}>
+            {m.email}{' '}
+            <RoleSelector value={m.role} onChange={(r) => handleRoleChange(m.id, r)} />
+            <button type="button" onClick={() => handleRemove(m.id)}>
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MemberList;

--- a/novaflow/src/features/workspaces/components/RoleSelector.tsx
+++ b/novaflow/src/features/workspaces/components/RoleSelector.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import type { Role } from '../api';
+
+interface Props {
+  value: Role;
+  onChange: (role: Role) => void;
+}
+
+const RoleSelector: React.FC<Props> = ({ value, onChange }) => (
+  <select value={value} onChange={(e) => onChange(e.target.value as Role)}>
+    <option value="member">Member</option>
+    <option value="admin">Admin</option>
+  </select>
+);
+
+export default RoleSelector;

--- a/novaflow/src/features/workspaces/components/WorkspaceCreationModal.tsx
+++ b/novaflow/src/features/workspaces/components/WorkspaceCreationModal.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { createWorkspace } from '../api';
+import type { Workspace } from '../store';
+
+interface Props {
+  ownerId: string;
+  onCreated: (workspace: Workspace) => void;
+  onClose: () => void;
+}
+
+const WorkspaceCreationModal: React.FC<Props> = ({ ownerId, onCreated, onClose }) => {
+  const [name, setName] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const workspace = await createWorkspace(name, ownerId);
+      onCreated(workspace);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="modal">
+      <form onSubmit={handleSubmit}>
+        <h3>Create Workspace</h3>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Workspace name"
+        />
+        <button type="submit">Create</button>
+        <button type="button" onClick={onClose}>
+          Cancel
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default WorkspaceCreationModal;

--- a/novaflow/src/features/workspaces/components/WorkspaceList.tsx
+++ b/novaflow/src/features/workspaces/components/WorkspaceList.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { fetchWorkspaces } from '../api';
+import { useWorkspaceStore, type Workspace } from '../store';
+import WorkspaceCreationModal from './WorkspaceCreationModal';
+
+interface Props {
+  userId: string;
+}
+
+const WorkspaceList: React.FC<Props> = ({ userId }) => {
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [showModal, setShowModal] = useState(false);
+  const setCurrentWorkspace = useWorkspaceStore((s) => s.setCurrentWorkspace);
+
+  useEffect(() => {
+    fetchWorkspaces(userId)
+      .then(setWorkspaces)
+      .catch((err) => console.error(err));
+  }, [userId]);
+
+  const handleCreated = (ws: Workspace) => {
+    setWorkspaces((prev) => [...prev, ws]);
+    setCurrentWorkspace(ws);
+    setShowModal(false);
+  };
+
+  return (
+    <div>
+      <h2>Workspaces</h2>
+      <ul>
+        {workspaces.map((ws) => (
+          <li key={ws.id}>
+            <button type="button" onClick={() => setCurrentWorkspace(ws)}>
+              {ws.name}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <button type="button" onClick={() => setShowModal(true)}>
+        Create Workspace
+      </button>
+      {showModal && (
+        <WorkspaceCreationModal
+          ownerId={userId}
+          onCreated={handleCreated}
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default WorkspaceList;

--- a/novaflow/src/features/workspaces/components/WorkspaceSwitcher.tsx
+++ b/novaflow/src/features/workspaces/components/WorkspaceSwitcher.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import { fetchWorkspaces } from '../api';
+import { useWorkspaceStore, type Workspace } from '../store';
+
+interface Props {
+  userId: string;
+}
+
+const WorkspaceSwitcher: React.FC<Props> = ({ userId }) => {
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const { currentWorkspace, setCurrentWorkspace } = useWorkspaceStore();
+
+  useEffect(() => {
+    fetchWorkspaces(userId)
+      .then(setWorkspaces)
+      .catch((err) => console.error(err));
+  }, [userId]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const ws = workspaces.find((w) => w.id === e.target.value);
+    if (ws) setCurrentWorkspace(ws);
+  };
+
+  return (
+    <select value={currentWorkspace?.id ?? ''} onChange={handleChange}>
+      <option value="" disabled>
+        Select workspace
+      </option>
+      {workspaces.map((ws) => (
+        <option key={ws.id} value={ws.id}>
+          {ws.name}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default WorkspaceSwitcher;

--- a/novaflow/src/features/workspaces/index.ts
+++ b/novaflow/src/features/workspaces/index.ts
@@ -1,0 +1,18 @@
+export { useWorkspaceStore } from './store';
+export type { Workspace } from './store';
+export {
+  fetchWorkspaces,
+  createWorkspace,
+  inviteMember,
+  listMembers,
+  updateMemberRole,
+  removeMember,
+  type Role,
+  type WorkspaceMember,
+} from './api';
+export { default as WorkspaceList } from './components/WorkspaceList';
+export { default as WorkspaceCreationModal } from './components/WorkspaceCreationModal';
+export { default as WorkspaceSwitcher } from './components/WorkspaceSwitcher';
+export { default as MemberInviteForm } from './components/MemberInviteForm';
+export { default as RoleSelector } from './components/RoleSelector';
+export { default as MemberList } from './components/MemberList';

--- a/novaflow/src/features/workspaces/store.test.ts
+++ b/novaflow/src/features/workspaces/store.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useWorkspaceStore, type Workspace } from './store';
+
+describe('useWorkspaceStore', () => {
+  beforeEach(() => {
+    useWorkspaceStore.getState().clear();
+  });
+
+  it('sets and clears current workspace', () => {
+    const ws: Workspace = { id: '1', name: 'Test' };
+    useWorkspaceStore.getState().setCurrentWorkspace(ws);
+    expect(useWorkspaceStore.getState().currentWorkspace).toEqual(ws);
+    useWorkspaceStore.getState().clear();
+    expect(useWorkspaceStore.getState().currentWorkspace).toBeNull();
+  });
+});

--- a/novaflow/src/features/workspaces/store.ts
+++ b/novaflow/src/features/workspaces/store.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+export interface Workspace {
+  id: string;
+  name: string;
+}
+
+interface WorkspaceState {
+  currentWorkspace: Workspace | null;
+  setCurrentWorkspace: (workspace: Workspace) => void;
+  clear: () => void;
+}
+
+export const useWorkspaceStore = create<WorkspaceState>((set) => ({
+  currentWorkspace: null,
+  setCurrentWorkspace: (workspace) => set({ currentWorkspace: workspace }),
+  clear: () => set({ currentWorkspace: null }),
+}));

--- a/novaflow/src/lib/index.ts
+++ b/novaflow/src/lib/index.ts
@@ -2,7 +2,7 @@
 
 // Permission utilities will be implemented here
 export const permissions = {
-  canEditProject: (user: any, workspace: any) => {
+  canEditProject: (user: { role: string }) => {
     return user.role === 'admin' || user.role === 'member';
   },
   // More permission functions will be added

--- a/novaflow/src/services/index.ts
+++ b/novaflow/src/services/index.ts
@@ -1,7 +1,7 @@
 // API services and Supabase wrappers
 
-// Supabase client will be configured here
-// export { supabase } from './supabase';
+// Supabase client configured for the application
+export { supabase } from './supabase';
 
 // Service abstractions will be implemented here
 export const apiService = {
@@ -10,5 +10,5 @@ export const apiService = {
 
 // Supabase service wrapper will be implemented here
 export const supabaseService = {
-  // Supabase operations will be abstracted here
+  client: null,
 };

--- a/novaflow/src/services/supabase.ts
+++ b/novaflow/src/services/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- add Supabase, Zustand, and Vitest tooling
- build workspace store, components, and API helpers
- support member invitations, role updates, and safe removal

## Testing
- `pnpm lint`
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fbaccff04832ba6230e4a3f318f09