### PR TITLE
feat: add file upload support

### DIFF
--- a/docs/features/file-uploads.md
+++ b/docs/features/file-uploads.md
@@ -17,8 +17,8 @@
 3. **Download/View:** User clicks file to download/view
 
 ## Supabase Usage
-- Supabase Storage for file data
-- `FileUploads` table for metadata
+- Supabase Storage buckets: `attachments` for task/project files and `avatars` for user images
+- `FileUploads` table for metadata linking uploads to tasks or projects
 
 ## UI/UX Notes
 - File picker for uploads
@@ -27,7 +27,7 @@
 
 ## Edge Cases
 - Invalid file type/size (validate client-side)
-- Orphaned files (clean up in future)
+- Orphaned files (periodic cleanup script removes unreferenced storage objects)
 
 ## Testing
 - Upload/download via UI

--- a/docs/supabase-schema.md
+++ b/docs/supabase-schema.md
@@ -93,6 +93,8 @@ This document describes the database schema for NovaFlow, implemented in Supabas
 ## FileUploads
 - `id` (UUID, PK)
 - `user_id` (UUID, FK → users.id)
+- `task_id` (UUID, FK → tasks.id, nullable)
+- `project_id` (UUID, FK → projects.id, nullable)
 - `file_url` (TEXT)
 - `type` (TEXT)
 - `created_at` (TIMESTAMP)

--- a/novaflow/src/App.tsx
+++ b/novaflow/src/App.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function App() {
   return (
     <div className="app">
@@ -9,4 +7,4 @@ function App() {
   );
 }
 
-export default App; 
+export default App;

--- a/novaflow/src/features/file-uploads/AttachmentList.tsx
+++ b/novaflow/src/features/file-uploads/AttachmentList.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { getPublicUrl } from '../../services';
+import type { FileUpload } from '../../types';
+
+interface AttachmentListProps {
+  items: FileUpload[];
+}
+
+/**
+ * Renders list of attachments with download links.
+ */
+export const AttachmentList: React.FC<AttachmentListProps> = ({ items }) => (
+  <ul>
+    {items.map((item) => {
+      const url = getPublicUrl(item.type as 'attachments' | 'avatars', item.file_url);
+      const name = item.file_url.split('/').pop();
+      return (
+        <li key={item.id}>
+          <a href={url} target="_blank" rel="noopener noreferrer">
+            {name}
+          </a>
+        </li>
+      );
+    })}
+  </ul>
+);

--- a/novaflow/src/features/file-uploads/FilePicker.tsx
+++ b/novaflow/src/features/file-uploads/FilePicker.tsx
@@ -1,0 +1,76 @@
+import React, { useRef } from 'react';
+import { APP_CONSTANTS } from '../../lib';
+import { uploadFile } from '../../services';
+import type { FileUpload } from '../../types';
+
+interface FilePickerProps {
+  bucket: 'attachments' | 'avatars';
+  userId: string;
+  workspaceId: string;
+  taskId?: string;
+  projectId?: string;
+  onUpload?: (uploads: FileUpload[]) => void;
+}
+
+/**
+ * Generic file picker component that validates file size/type before upload.
+ */
+export const FilePicker: React.FC<FilePickerProps> = ({
+  bucket,
+  userId,
+  workspaceId,
+  taskId,
+  projectId,
+  onUpload,
+}) => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleChange = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): Promise<void> => {
+    const files = event.target.files ? Array.from(event.target.files) : [];
+    const valid: File[] = [];
+
+    files.forEach((file) => {
+      if (file.size > APP_CONSTANTS.MAX_FILE_SIZE) {
+        alert(`File ${file.name} exceeds maximum size`);
+        return;
+      }
+      if (
+        bucket === 'avatars' &&
+        !APP_CONSTANTS.SUPPORTED_IMAGE_TYPES.includes(file.type)
+      ) {
+        alert(`Unsupported file type: ${file.type}`);
+        return;
+      }
+      valid.push(file);
+    });
+
+    const uploads: FileUpload[] = [];
+    for (const file of valid) {
+      // sequential upload to simplify
+      const uploaded = await uploadFile({
+        bucket,
+        file,
+        userId,
+        workspaceId,
+        taskId,
+        projectId,
+      });
+      uploads.push(uploaded);
+    }
+    onUpload?.(uploads);
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  };
+
+  return (
+    <input
+      ref={inputRef}
+      type="file"
+      onChange={handleChange}
+      multiple={bucket === 'attachments'}
+    />
+  );
+};

--- a/novaflow/src/features/file-uploads/index.ts
+++ b/novaflow/src/features/file-uploads/index.ts
@@ -1,0 +1,2 @@
+export { FilePicker } from './FilePicker';
+export { AttachmentList } from './AttachmentList';

--- a/novaflow/src/features/projects/ProjectForm.tsx
+++ b/novaflow/src/features/projects/ProjectForm.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { FilePicker, AttachmentList } from '../file-uploads';
+import type { FileUpload } from '../../types';
+
+interface ProjectFormProps {
+  userId: string;
+  workspaceId: string;
+}
+
+/**
+ * Simple project form with attachment uploads.
+ */
+export const ProjectForm: React.FC<ProjectFormProps> = ({ userId, workspaceId }) => {
+  const [attachments, setAttachments] = useState<FileUpload[]>([]);
+
+  const handleUpload = (files: FileUpload[]): void => {
+    setAttachments((prev) => [...prev, ...files]);
+  };
+
+  return (
+    <form>
+      <input type="text" placeholder="Project title" />
+      <FilePicker
+        bucket="attachments"
+        userId={userId}
+        workspaceId={workspaceId}
+        onUpload={handleUpload}
+      />
+      <AttachmentList items={attachments} />
+    </form>
+  );
+};

--- a/novaflow/src/features/projects/index.ts
+++ b/novaflow/src/features/projects/index.ts
@@ -1,0 +1,1 @@
+export { ProjectForm } from './ProjectForm';

--- a/novaflow/src/features/tasks/TaskForm.tsx
+++ b/novaflow/src/features/tasks/TaskForm.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { FilePicker, AttachmentList } from '../file-uploads';
+import type { FileUpload } from '../../types';
+
+interface TaskFormProps {
+  userId: string;
+  workspaceId: string;
+}
+
+/**
+ * Simple task form showcasing attachment uploads.
+ */
+export const TaskForm: React.FC<TaskFormProps> = ({ userId, workspaceId }) => {
+  const [attachments, setAttachments] = useState<FileUpload[]>([]);
+
+  const handleUpload = (files: FileUpload[]): void => {
+    setAttachments((prev) => [...prev, ...files]);
+  };
+
+  return (
+    <form>
+      <input type="text" placeholder="Task title" />
+      <FilePicker
+        bucket="attachments"
+        userId={userId}
+        workspaceId={workspaceId}
+        onUpload={handleUpload}
+      />
+      <AttachmentList items={attachments} />
+    </form>
+  );
+};

--- a/novaflow/src/features/tasks/index.ts
+++ b/novaflow/src/features/tasks/index.ts
@@ -1,0 +1,1 @@
+export { TaskForm } from './TaskForm';

--- a/novaflow/src/features/users/ProfilePage.tsx
+++ b/novaflow/src/features/users/ProfilePage.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { FilePicker } from '../file-uploads';
+import type { FileUpload } from '../../types';
+import { getPublicUrl } from '../../services';
+
+interface ProfilePageProps {
+  userId: string;
+  workspaceId: string;
+}
+
+/**
+ * Minimal profile page demonstrating avatar upload.
+ */
+export const ProfilePage: React.FC<ProfilePageProps> = ({
+  userId,
+  workspaceId,
+}) => {
+  const [avatar, setAvatar] = useState<FileUpload | null>(null);
+
+  const handleUpload = (files: FileUpload[]): void => {
+    if (files.length > 0) {
+      setAvatar(files[0]);
+    }
+  };
+
+  const avatarUrl = avatar
+    ? getPublicUrl('avatars', avatar.file_url)
+    : undefined;
+
+  return (
+    <div>
+      {avatarUrl && <img src={avatarUrl} alt="avatar" width={100} />}
+      <FilePicker
+        bucket="avatars"
+        userId={userId}
+        workspaceId={workspaceId}
+        onUpload={handleUpload}
+      />
+    </div>
+  );
+};

--- a/novaflow/src/features/users/index.ts
+++ b/novaflow/src/features/users/index.ts
@@ -1,0 +1,1 @@
+export { ProfilePage } from './ProfilePage';

--- a/novaflow/src/lib/index.ts
+++ b/novaflow/src/lib/index.ts
@@ -1,10 +1,11 @@
 // Utilities, constants, and permission logic
 
 // Permission utilities will be implemented here
+import type { User } from '../types';
+
 export const permissions = {
-  canEditProject: (user: any, workspace: any) => {
-    return user.role === 'admin' || user.role === 'member';
-  },
+  canEditProject: (user: User): boolean =>
+    user.role === 'admin' || user.role === 'member',
   // More permission functions will be added
 };
 

--- a/novaflow/src/services/index.ts
+++ b/novaflow/src/services/index.ts
@@ -1,14 +1,2 @@
-// API services and Supabase wrappers
-
-// Supabase client will be configured here
-// export { supabase } from './supabase';
-
-// Service abstractions will be implemented here
-export const apiService = {
-  // API methods will be added here
-};
-
-// Supabase service wrapper will be implemented here
-export const supabaseService = {
-  // Supabase operations will be abstracted here
-};
+// Central export for service utilities
+export { uploadFile, listAttachments, getPublicUrl } from './supabase';

--- a/novaflow/src/services/supabase.ts
+++ b/novaflow/src/services/supabase.ts
@@ -1,0 +1,94 @@
+import type { FileUpload } from '../types';
+
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+/**
+ * Perform a fetch request against the Supabase REST API with the anon key.
+ */
+async function supabaseFetch(path: string, options: RequestInit = {}): Promise<Response> {
+  const headers = {
+    apikey: SUPABASE_ANON_KEY,
+    Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+    ...(options.headers || {}),
+  } as Record<string, string>;
+  return fetch(`${SUPABASE_URL}${path}`, { ...options, headers });
+}
+
+/**
+ * Upload a file to a storage bucket and record metadata in FileUploads.
+ */
+export async function uploadFile(params: {
+  bucket: 'attachments' | 'avatars';
+  file: File;
+  userId: string;
+  workspaceId: string;
+  taskId?: string;
+  projectId?: string;
+}): Promise<FileUpload> {
+  const { bucket, file, userId, workspaceId, taskId, projectId } = params;
+  const filePath = `${userId}/${Date.now()}-${file.name}`;
+
+  const uploadRes = await supabaseFetch(`/storage/v1/object/${bucket}/${filePath}`, {
+    method: 'POST',
+    body: file,
+    headers: { 'Content-Type': file.type || 'application/octet-stream' },
+  });
+
+  if (!uploadRes.ok) {
+    throw new Error('Failed to upload file');
+  }
+
+  const metadata = {
+    user_id: userId,
+    file_url: filePath,
+    type: bucket,
+    workspace_id: workspaceId,
+    task_id: taskId,
+    project_id: projectId,
+  } as Record<string, unknown>;
+
+  const metaRes = await supabaseFetch('/rest/v1/FileUploads', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Prefer: 'return=representation' },
+    body: JSON.stringify(metadata),
+  });
+
+  if (!metaRes.ok) {
+    throw new Error('Failed to store file metadata');
+  }
+
+  const [record] = (await metaRes.json()) as FileUpload[];
+  return record;
+}
+
+/**
+ * List attachments for a task or project.
+ */
+export async function listAttachments(filter: {
+  taskId?: string;
+  projectId?: string;
+}): Promise<FileUpload[]> {
+  const url = new URL(`${SUPABASE_URL}/rest/v1/FileUploads`);
+  url.searchParams.set('select', '*');
+  if (filter.taskId) url.searchParams.set('task_id', `eq.${filter.taskId}`);
+  if (filter.projectId) url.searchParams.set('project_id', `eq.${filter.projectId}`);
+
+  const res = await fetch(url.toString(), {
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to list attachments');
+  }
+  return (await res.json()) as FileUpload[];
+}
+
+/**
+ * Generate a public URL for a file in storage.
+ */
+export function getPublicUrl(bucket: 'attachments' | 'avatars', path: string): string {
+  return `${SUPABASE_URL}/storage/v1/object/public/${bucket}/${path}`;
+}

--- a/novaflow/src/types/index.ts
+++ b/novaflow/src/types/index.ts
@@ -55,4 +55,16 @@ export interface TaskDependency {
   type: 'blocks' | 'relates_to';
 }
 
+// File upload metadata stored in Supabase
+export interface FileUpload {
+  id: string;
+  user_id: string;
+  file_url: string;
+  type: string;
+  created_at: string;
+  workspace_id: string;
+  task_id?: string;
+  project_id?: string;
+}
+
 // Additional types will be added as features are developed

--- a/scripts/cleanup-orphaned-files.ts
+++ b/scripts/cleanup-orphaned-files.ts
@@ -1,0 +1,52 @@
+/* eslint-env node */
+import { FileUpload } from '../novaflow/src/types';
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? '';
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY ?? '';
+
+async function supabaseFetch(path: string, options: RequestInit = {}): Promise<Response> {
+  const headers = {
+    apikey: SERVICE_KEY,
+    Authorization: `Bearer ${SERVICE_KEY}`,
+    ...(options.headers || {}),
+  } as Record<string, string>;
+  return fetch(`${SUPABASE_URL}${path}`, { ...options, headers });
+}
+
+async function listStoredObjects(bucket: string): Promise<string[]> {
+  const res = await supabaseFetch(`/storage/v1/object/list/${bucket}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prefix: '' }),
+  });
+  if (!res.ok) return [];
+  const data = (await res.json()) as { name: string }[];
+  return data.map((o) => o.name);
+}
+
+async function listRecordedFiles(): Promise<FileUpload[]> {
+  const res = await supabaseFetch('/rest/v1/FileUploads?select=*');
+  if (!res.ok) return [];
+  return (await res.json()) as FileUpload[];
+}
+
+/**
+ * Removes files in storage that lack corresponding FileUploads records.
+ */
+export async function cleanupOrphanedFiles(): Promise<void> {
+  const [records, stored] = await Promise.all([
+    listRecordedFiles(),
+    listStoredObjects('attachments'),
+  ]);
+  const recordedPaths = new Set(records.map((r) => r.file_url));
+  const orphans = stored.filter((p) => !recordedPaths.has(p));
+  for (const path of orphans) {
+    // eslint-disable-next-line no-await-in-loop
+    await supabaseFetch(`/storage/v1/object/attachments/${path}`, {
+      method: 'DELETE',
+    });
+  }
+}
+
+// Execute when run directly
+cleanupOrphanedFiles();

--- a/supabase/migrations/20240803_file_uploads.sql
+++ b/supabase/migrations/20240803_file_uploads.sql
@@ -1,0 +1,20 @@
+-- Create storage buckets for attachments and avatars
+insert into storage.buckets (id, name, public)
+values ('attachments', 'attachments', true)
+on conflict (id) do nothing;
+
+insert into storage.buckets (id, name, public)
+values ('avatars', 'avatars', true)
+on conflict (id) do nothing;
+
+-- Metadata table for uploaded files
+create table if not exists public."FileUploads" (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users (id),
+  task_id uuid references public."Tasks" (id),
+  project_id uuid references public."Projects" (id),
+  workspace_id uuid references public."Workspaces" (id),
+  file_url text not null,
+  type text not null,
+  created_at timestamp with time zone default timezone('utc', now())
+);


### PR DESCRIPTION
## Summary
- add Supabase buckets and FileUploads metadata table
- create file picker and attachment list components
- wire uploads into task/project/profile forms with validation
- include cleanup script for orphaned files

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688fbad27528832b8da3fc0a61003f6f