### PR TITLE
Add Notification context and panel

### DIFF
--- a/novaflow/package.json
+++ b/novaflow/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -24,6 +25,9 @@
     "globals": "^16.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^16.0.0",
+    "jsdom": "^25.0.0"
   }
 }

--- a/novaflow/src/context/NotificationContext.tsx
+++ b/novaflow/src/context/NotificationContext.tsx
@@ -1,0 +1,98 @@
+import React, { createContext, useContext, useCallback, useEffect, useState } from 'react';
+
+// Types
+export interface NotificationItem {
+  id: string;
+  type: 'mention' | 'task_assignment' | string;
+  message: string;
+  read: boolean;
+  createdAt: Date;
+}
+
+export interface NotifyInput {
+  id: string;
+  type?: NotificationItem['type'];
+  message?: string;
+  createdAt?: Date;
+}
+
+interface NotificationContextValue {
+  items: NotificationItem[];
+  notify: (input: NotifyInput) => void;
+  markAsRead: (id: string) => void;
+}
+
+const NotificationContext = createContext<NotificationContextValue | undefined>(undefined);
+
+function defaultMessage(type?: string): string {
+  switch (type) {
+    case 'mention':
+      return 'You were mentioned.';
+    case 'task_assignment':
+      return 'You were assigned a task.';
+    default:
+      return 'You have a new notification.';
+  }
+}
+
+export const NotificationProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [items, setItems] = useState<NotificationItem[]>([]);
+
+  const notify = useCallback((input: NotifyInput) => {
+    setItems(prev => {
+      if (prev.some(n => n.id === input.id)) return prev; // dedupe
+      const item: NotificationItem = {
+        id: input.id,
+        type: input.type || 'general',
+        message: input.message || defaultMessage(input.type),
+        read: false,
+        createdAt: input.createdAt || new Date(),
+      };
+      return [item, ...prev];
+    });
+  }, []);
+
+  const markAsRead = useCallback((id: string) => {
+    setItems(prev => prev.map(n => (n.id === id ? { ...n, read: true } : n)));
+  }, []);
+
+  useEffect(() => {
+    const handleMention = (e: Event) => {
+      const detail = (e as CustomEvent).detail || {};
+      notify({
+        id: detail.id,
+        type: 'mention',
+        message: detail.user ? `${detail.user} mentioned you` : undefined,
+      });
+    };
+    const handleAssignment = (e: Event) => {
+      const detail = (e as CustomEvent).detail || {};
+      notify({
+        id: detail.id,
+        type: 'task_assignment',
+        message: detail.task ? `You were assigned to ${detail.task}` : undefined,
+      });
+    };
+    window.addEventListener('mention', handleMention as EventListener);
+    window.addEventListener('task-assignment', handleAssignment as EventListener);
+    return () => {
+      window.removeEventListener('mention', handleMention as EventListener);
+      window.removeEventListener('task-assignment', handleAssignment as EventListener);
+    };
+  }, [notify]);
+
+  return (
+    <NotificationContext.Provider value={{ items, notify, markAsRead }}>
+      {children}
+    </NotificationContext.Provider>
+  );
+};
+
+export function useNotification(): NotificationContextValue {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) {
+    throw new Error('useNotification must be used within NotificationProvider');
+  }
+  return ctx;
+}
+

--- a/novaflow/src/context/index.ts
+++ b/novaflow/src/context/index.ts
@@ -1,12 +1,8 @@
 // React context providers for global state
 
-// AuthContext will be implemented here
-// export { AuthProvider, useAuth } from './AuthContext';
+export { NotificationProvider, useNotification } from './NotificationContext';
 
-// NotificationContext will be implemented here  
-// export { NotificationProvider, useNotification } from './NotificationContext';
-
-// Placeholder exports
+// Placeholder exports for additional contexts
 export const contextProviders = {
-  // Context providers will be exported here
+  NotificationProvider,
 };

--- a/novaflow/src/features/notifications/NotificationContext.test.tsx
+++ b/novaflow/src/features/notifications/NotificationContext.test.tsx
@@ -1,0 +1,66 @@
+import { renderHook, act, render, screen } from '@testing-library/react';
+import React from 'react';
+import { NotificationProvider, useNotification } from '../../context/NotificationContext';
+import NotificationPanel from './NotificationPanel';
+
+describe('NotificationContext', () => {
+  const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+    <NotificationProvider>{children}</NotificationProvider>
+  );
+
+  it('deduplicates notifications', () => {
+    const { result } = renderHook(() => useNotification(), { wrapper });
+
+    act(() => {
+      result.current.notify({ id: '1', message: 'Hello' });
+      result.current.notify({ id: '1', message: 'Duplicate' });
+    });
+
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].message).toBe('Hello');
+  });
+
+  it('marks notifications as read', () => {
+    const { result } = renderHook(() => useNotification(), { wrapper });
+
+    act(() => {
+      result.current.notify({ id: 'read-test', message: 'Mark me' });
+      result.current.markAsRead('read-test');
+    });
+
+    expect(result.current.items[0].read).toBe(true);
+  });
+
+  it('subscribes to mention events and handles missing data', () => {
+    const { result } = renderHook(() => useNotification(), { wrapper });
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('mention', { detail: { id: 'm1', user: 'Alice' } })
+      );
+      window.dispatchEvent(new CustomEvent('mention', { detail: { id: 'm2' } }));
+    });
+
+    const m1 = result.current.items.find(n => n.id === 'm1');
+    const m2 = result.current.items.find(n => n.id === 'm2');
+    expect(m1?.message).toContain('Alice');
+    expect(m2?.message).toBe('You were mentioned.');
+  });
+});
+
+describe('NotificationPanel', () => {
+  it('renders unique notifications', () => {
+    render(
+      <NotificationProvider>
+        <NotificationPanel />
+      </NotificationProvider>
+    );
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('mention', { detail: { id: 'p1', user: 'Bob' } }));
+      window.dispatchEvent(new CustomEvent('mention', { detail: { id: 'p1', user: 'Bob' } }));
+    });
+
+    expect(screen.getAllByTestId('notification-p1').length).toBe(1);
+  });
+});

--- a/novaflow/src/features/notifications/NotificationPanel.tsx
+++ b/novaflow/src/features/notifications/NotificationPanel.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useNotification } from '../../context/NotificationContext';
+
+const NotificationPanel: React.FC = () => {
+  const { items, markAsRead } = useNotification();
+
+  const uniqueItems = React.useMemo(() => {
+    const map = new Map<string, typeof items[number]>();
+    for (const n of items) {
+      if (!map.has(n.id)) map.set(n.id, n);
+    }
+    return Array.from(map.values());
+  }, [items]);
+
+  if (uniqueItems.length === 0) {
+    return <div>No notifications</div>;
+  }
+
+  return (
+    <ul>
+      {uniqueItems.map(n => (
+        <li key={n.id} data-testid={`notification-${n.id}`}>
+          <span>{n.message}</span>
+          {!n.read && (
+            <button onClick={() => markAsRead(n.id)}>Mark read</button>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default NotificationPanel;

--- a/novaflow/src/features/notifications/index.ts
+++ b/novaflow/src/features/notifications/index.ts
@@ -1,0 +1,1 @@
+export { default as NotificationPanel } from './NotificationPanel';

--- a/novaflow/vite.config.ts
+++ b/novaflow/vite.config.ts
@@ -1,7 +1,10 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  test: {
+    environment: 'jsdom',
+  },
+});


### PR DESCRIPTION
## Summary
- implement React notification context with realtime subscriptions
- add notification panel component and exports
- configure vitest and unit tests for notification flows

## Testing
- `pnpm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fbad50f34832b9a48c145b27c30a5