### PR TITLE
feat(search): add search components and manual index updater

### DIFF
--- a/novaflow/package.json
+++ b/novaflow/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@mantine/core": "^7.14.2",
+    "@mantine/hooks": "^7.14.2",
+    "@supabase/supabase-js": "^2.45.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/novaflow/scripts/update-search-index.js
+++ b/novaflow/scripts/update-search-index.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * Manually update the SearchIndex table.
+ * Usage: node scripts/update-search-index.js <id> <type> <content> <link>
+ * Requires VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY env vars.
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const [id, type, content, link] = process.argv.slice(2);
+
+if (!id || !type || !content || !link) {
+  console.error('Usage: node scripts/update-search-index.js <id> <type> <content> <link>');
+  process.exit(1);
+}
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL || '';
+const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY || '';
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+const run = async () => {
+  const { error } = await supabase.from('SearchIndex').insert([
+    { id, type, content, link },
+  ]);
+  if (error) {
+    console.error('Index update failed:', error.message);
+    process.exit(1);
+  }
+  console.log('Search index updated');
+};
+
+run();

--- a/novaflow/src/App.tsx
+++ b/novaflow/src/App.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function App() {
   return (
     <div className="app">

--- a/novaflow/src/features/search/SearchBar.tsx
+++ b/novaflow/src/features/search/SearchBar.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { Autocomplete, Loader } from '@mantine/core';
+import { supabase } from '../../services/supabase';
+import type { SearchResult } from './types';
+
+interface SearchBarProps {
+  onResults: (results: SearchResult[]) => void;
+}
+
+export function SearchBar({ onResults }: SearchBarProps) {
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+
+  const handleChange = async (value: string) => {
+    setQuery(value);
+    if (!value.trim()) {
+      onResults([]);
+      setSuggestions([]);
+      return;
+    }
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('SearchIndex')
+      .select('id, type, content, link')
+      .textSearch('content', value);
+    setLoading(false);
+    if (error || !data) {
+      console.error('Search failed', error);
+      onResults([]);
+      setSuggestions([]);
+      return;
+    }
+    interface SearchIndexRow {
+      id: string;
+      type: string;
+      content: string;
+      link: string;
+    }
+    const results = data.map((row: SearchIndexRow) => ({
+      id: row.id,
+      type: row.type,
+      snippet: row.content.slice(0, 100),
+      link: row.link,
+    }));
+    setSuggestions(results.map((r: SearchResult) => r.snippet));
+    onResults(results);
+  };
+
+  return (
+    <Autocomplete
+      placeholder="Search"
+      value={query}
+      onChange={handleChange}
+      data={suggestions}
+      rightSection={loading ? <Loader size="xs" /> : null}
+    />
+  );
+}

--- a/novaflow/src/features/search/SearchResults.tsx
+++ b/novaflow/src/features/search/SearchResults.tsx
@@ -1,0 +1,27 @@
+import { Anchor, List, Text } from '@mantine/core';
+import type { SearchResult } from './types';
+
+interface SearchResultsProps {
+  results: SearchResult[];
+}
+
+export function SearchResults({ results }: SearchResultsProps) {
+  if (!results.length) {
+    return <Text>No results found.</Text>;
+  }
+
+  return (
+    <List spacing="sm">
+      {results.map((r) => (
+        <List.Item key={r.id}>
+          <Anchor href={r.link}>
+            <Text fw={500}>{r.type}</Text>
+            <Text size="sm" c="dimmed">
+              {r.snippet}
+            </Text>
+          </Anchor>
+        </List.Item>
+      ))}
+    </List>
+  );
+}

--- a/novaflow/src/features/search/index.ts
+++ b/novaflow/src/features/search/index.ts
@@ -1,0 +1,4 @@
+export { SearchBar } from './SearchBar';
+export { SearchResults } from './SearchResults';
+export { useSearchIndexUpdater } from './useSearchIndexUpdater';
+export type { SearchResult, SearchIndexEntry } from './types';

--- a/novaflow/src/features/search/types.ts
+++ b/novaflow/src/features/search/types.ts
@@ -1,0 +1,13 @@
+export interface SearchResult {
+  id: string;
+  type: string;
+  snippet: string;
+  link: string;
+}
+
+export interface SearchIndexEntry {
+  id: string;
+  type: string;
+  content: string;
+  link: string;
+}

--- a/novaflow/src/features/search/useSearchIndexUpdater.ts
+++ b/novaflow/src/features/search/useSearchIndexUpdater.ts
@@ -1,0 +1,11 @@
+import { supabase } from '../../services/supabase';
+import type { SearchIndexEntry } from './types';
+
+// Hook providing manual SearchIndex updates. Replace with automated indexing in future phases.
+export function useSearchIndexUpdater() {
+  const updateIndex = async (entry: SearchIndexEntry) => {
+    return supabase.from('SearchIndex').insert([entry]);
+  };
+
+  return { updateIndex };
+}

--- a/novaflow/src/lib/index.ts
+++ b/novaflow/src/lib/index.ts
@@ -1,8 +1,12 @@
 // Utilities, constants, and permission logic
 
 // Permission utilities will be implemented here
+interface UserLike {
+  role: string;
+}
+
 export const permissions = {
-  canEditProject: (user: any, workspace: any) => {
+  canEditProject: (user: UserLike) => {
     return user.role === 'admin' || user.role === 'member';
   },
   // More permission functions will be added

--- a/novaflow/src/services/index.ts
+++ b/novaflow/src/services/index.ts
@@ -1,7 +1,7 @@
 // API services and Supabase wrappers
 
-// Supabase client will be configured here
-// export { supabase } from './supabase';
+// Supabase client configured via environment variables
+export { supabase } from './supabase';
 
 // Service abstractions will be implemented here
 export const apiService = {

--- a/novaflow/src/services/supabase.ts
+++ b/novaflow/src/services/supabase.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = (import.meta.env.VITE_SUPABASE_URL as string) || '';
+const supabaseAnonKey = (import.meta.env.VITE_SUPABASE_ANON_KEY as string) || '';
+
+// Supabase client configured from environment variables.
+// Keys are not hardcoded to avoid leaking credentials.
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+


### PR DESCRIPTION
## Summary
- add Mantine-powered `SearchBar` and `SearchResults` components querying Supabase `SearchIndex`
- expose `useSearchIndexUpdater` hook and CLI script for manual index maintenance
- configure Supabase client and integrate new dependencies

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Cannot find module '@mantine/core' or '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_688fbad6b7e8832b818f98d061c5d38f