### PR TITLE
feat: add activity logging and panel

### DIFF
--- a/novaflow/package.json
+++ b/novaflow/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "@supabase/supabase-js": "^2.48.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/novaflow/src/App.tsx
+++ b/novaflow/src/App.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function App() {
   return (
     <div className="app">
@@ -9,4 +7,4 @@ function App() {
   );
 }
 
-export default App; 
+export default App;

--- a/novaflow/src/features/activity-log/ActivityLogPanel.tsx
+++ b/novaflow/src/features/activity-log/ActivityLogPanel.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useState } from 'react';
+import { supabase } from '../../services/supabase';
+
+interface ActivityLogEntry {
+  id: string;
+  actor_id: string;
+  action: string;
+  entity_type: string;
+  entity_id: string;
+  workspace_id: string;
+  metadata: Record<string, unknown> | null;
+  timestamp: string;
+}
+
+interface ActivityLogPanelProps {
+  workspaceId: string;
+  limit?: number;
+}
+
+/**
+ * Panel component displaying activity log entries for a workspace.
+ * Supports basic pagination and realtime updates via Supabase Realtime.
+ */
+export const ActivityLogPanel = ({ workspaceId, limit = 20 }: ActivityLogPanelProps) => {
+  const [logs, setLogs] = useState<ActivityLogEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [page, setPage] = useState(1);
+  const [filter, setFilter] = useState('');
+
+  const fetchLogs = useCallback(
+    async (pageNum: number) => {
+      setLoading(true);
+      const from = (pageNum - 1) * limit;
+      const to = from + limit - 1;
+      const { data, error } = await supabase
+        .from<ActivityLogEntry>('ActivityLog')
+        .select('*')
+        .eq('workspace_id', workspaceId)
+        .order('timestamp', { ascending: false })
+        .range(from, to);
+      if (!error && data) {
+        setLogs(prev => (pageNum === 1 ? data : [...prev, ...data]));
+      }
+      setLoading(false);
+    },
+    [workspaceId, limit]
+  );
+
+  useEffect(() => {
+    fetchLogs(1);
+    const channel = supabase
+      .channel('activity-log-channel')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'ActivityLog', filter: `workspace_id=eq.${workspaceId}` },
+        (payload: { new: ActivityLogEntry }) => {
+          setLogs(prev => [payload.new, ...prev]);
+        }
+      )
+      .subscribe();
+
+    return () => {
+      void channel.unsubscribe();
+    };
+  }, [workspaceId, fetchLogs]);
+
+  const handleLoadMore = () => {
+    const nextPage = page + 1;
+    setPage(nextPage);
+    void fetchLogs(nextPage);
+  };
+
+  const filteredLogs = logs.filter(log => {
+    const term = filter.toLowerCase();
+    return (
+      log.action.toLowerCase().includes(term) ||
+      log.entity_type.toLowerCase().includes(term)
+    );
+  });
+
+  return (
+    <div>
+      <input
+        type="text"
+        placeholder="Filter by action or entity"
+        value={filter}
+        onChange={e => setFilter(e.target.value)}
+      />
+      <ul>
+        {filteredLogs.map(log => {
+          const meta = log.metadata as Record<string, unknown> | null;
+          const name =
+            (typeof meta?.['name'] === 'string' && (meta['name'] as string)) ||
+            (typeof meta?.['title'] === 'string' && (meta['title'] as string));
+          const entityDisplay = name || `[Deleted ${log.entity_type}]`;
+
+          return (
+            <li key={log.id}>
+              <strong>{log.actor_id}</strong> {log.action} {entityDisplay} –
+              <em>{new Date(log.timestamp).toLocaleString()}</em>
+            </li>
+          );
+        })}
+      </ul>
+      {filteredLogs.length === 0 && !loading && <div>No activity yet.</div>}
+      {loading && <div>Loading...</div>}
+      <button onClick={handleLoadMore} disabled={loading}>
+        Load more
+      </button>
+    </div>
+  );
+};

--- a/novaflow/src/features/activity-log/index.ts
+++ b/novaflow/src/features/activity-log/index.ts
@@ -1,0 +1,1 @@
+export { ActivityLogPanel } from './ActivityLogPanel';

--- a/novaflow/src/lib/activity.ts
+++ b/novaflow/src/lib/activity.ts
@@ -1,0 +1,23 @@
+import { supabase } from '../services/supabase';
+
+export interface ActivityLogPayload {
+  actor_id: string;
+  action: string;
+  entity_type: string;
+  entity_id: string;
+  workspace_id: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Insert a new activity log entry. Intended to be called after CRUD events.
+ * Throws an error if the insert fails so callers can handle failures.
+ */
+export const logActivity = async (payload: ActivityLogPayload): Promise<void> => {
+  const entry = { ...payload, timestamp: new Date().toISOString() };
+  const { error } = await supabase.from('ActivityLog').insert([entry]);
+  if (error) {
+    // Surface the error so callers can handle it (toast, etc.)
+    throw error;
+  }
+};

--- a/novaflow/src/lib/index.ts
+++ b/novaflow/src/lib/index.ts
@@ -1,8 +1,29 @@
 // Utilities, constants, and permission logic
 
+export { logActivity } from './activity';
+
 // Permission utilities will be implemented here
+
+/**
+ * Basic representation of a user used for permission checks.
+ * Additional fields can be added as needed.
+ */
+interface User {
+  role: string;
+}
+
+/**
+ * Placeholder workspace type.
+ * The workspace is currently unused but kept for API compatibility with
+ * future permission helpers.
+ */
+interface Workspace {
+  id?: string;
+}
+
 export const permissions = {
-  canEditProject: (user: any, workspace: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  canEditProject: (user: User, _workspace: Workspace) => {
     return user.role === 'admin' || user.role === 'member';
   },
   // More permission functions will be added

--- a/novaflow/src/services/index.ts
+++ b/novaflow/src/services/index.ts
@@ -1,7 +1,7 @@
 // API services and Supabase wrappers
 
-// Supabase client will be configured here
-// export { supabase } from './supabase';
+// Supabase client
+export { supabase } from './supabase';
 
 // Service abstractions will be implemented here
 export const apiService = {

--- a/novaflow/src/services/supabase.ts
+++ b/novaflow/src/services/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- implement Supabase helper `logActivity` for CRUD events
- build `ActivityLogPanel` with realtime updates, filtering, and pagination
- expose Supabase client and helper exports

## Testing
- `pnpm lint`
- `pnpm install` *(fails: GET https://registry.npmjs.org/@supabase%2Fsupabase-js: Forbidden - 403)*
- `pnpm build` *(fails: Cannot find module '@supabase/supabase-js')*


------
https://chatgpt.com/codex/tasks/task_e_688fbad60190832b8200eae294901bcc