### PR TITLE
feat: add task management components

### DIFF
--- a/novaflow/package.json
+++ b/novaflow/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.63.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/novaflow/src/App.tsx
+++ b/novaflow/src/App.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function App() {
   return (
     <div className="app">

--- a/novaflow/src/features/tasks/README.md
+++ b/novaflow/src/features/tasks/README.md
@@ -1,0 +1,4 @@
+# Tasks Feature
+
+This module provides task management components including a Kanban-style board,
+CRUD forms, and dependency handling powered by React Query.

--- a/novaflow/src/features/tasks/api.ts
+++ b/novaflow/src/features/tasks/api.ts
@@ -1,0 +1,77 @@
+import { hasCircularDependency } from './utils'
+import type { Task, TaskInput } from './types'
+
+const STORAGE_KEY = 'novaflow.tasks'
+
+function load(): Task[] {
+  if (typeof localStorage === 'undefined') return []
+  const raw = localStorage.getItem(STORAGE_KEY)
+  return raw ? (JSON.parse(raw) as Task[]) : []
+}
+
+function save(tasks: Task[]): void {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks))
+}
+
+export async function listTasks(): Promise<Task[]> {
+  return load()
+}
+
+export async function createTask(input: TaskInput): Promise<Task> {
+  const tasks = load()
+  const task: Task = {
+    id: Date.now().toString(),
+    dependencies: [],
+    ...input,
+  }
+  tasks.push(task)
+  save(tasks)
+  return task
+}
+
+export async function updateTask(id: string, input: TaskInput): Promise<Task> {
+  const tasks = load()
+  const index = tasks.findIndex((t) => t.id === id)
+  if (index === -1) throw new Error('Task not found')
+  const updated = { ...tasks[index], ...input }
+  tasks[index] = updated
+  save(tasks)
+  return updated
+}
+
+export async function deleteTask(id: string): Promise<void> {
+  const tasks = load()
+  const hasDependents = tasks.some((t) => t.dependencies.includes(id))
+  if (hasDependents) {
+    throw new Error('Task has dependent tasks')
+  }
+  save(tasks.filter((t) => t.id !== id))
+}
+
+export async function addDependency(
+  taskId: string,
+  dependencyId: string,
+): Promise<void> {
+  const tasks = load()
+  if (hasCircularDependency(taskId, dependencyId, tasks)) {
+    throw new Error('Circular dependency detected')
+  }
+  const task = tasks.find((t) => t.id === taskId)
+  if (task && !task.dependencies.includes(dependencyId)) {
+    task.dependencies.push(dependencyId)
+    save(tasks)
+  }
+}
+
+export async function removeDependency(
+  taskId: string,
+  dependencyId: string,
+): Promise<void> {
+  const tasks = load()
+  const task = tasks.find((t) => t.id === taskId)
+  if (task) {
+    task.dependencies = task.dependencies.filter((d) => d !== dependencyId)
+    save(tasks)
+  }
+}

--- a/novaflow/src/features/tasks/components/DependencyModal.tsx
+++ b/novaflow/src/features/tasks/components/DependencyModal.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { useAddDependency, useRemoveDependency, useTasks } from '../hooks'
+import { hasCircularDependency } from '../utils'
+import type { Task } from '../types'
+
+interface Props {
+  task: Task
+  onClose: () => void
+}
+
+export const DependencyModal: React.FC<Props> = ({ task, onClose }) => {
+  const { data: tasks = [] } = useTasks()
+  const addDep = useAddDependency()
+  const removeDep = useRemoveDependency()
+
+  const toggle = (id: string) => {
+    if (task.dependencies.includes(id)) {
+      removeDep.mutate({ taskId: task.id, dependencyId: id })
+    } else {
+      if (hasCircularDependency(task.id, id, tasks)) {
+        alert('Circular dependency detected')
+        return
+      }
+      addDep.mutate({ taskId: task.id, dependencyId: id })
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+      <div className="bg-white p-4 w-80 space-y-2">
+        <h2 className="font-bold">Dependencies for {task.title}</h2>
+        <ul className="max-h-60 overflow-y-auto">
+          {tasks
+            .filter((t: Task) => t.id !== task.id)
+            .map((t: Task) => (
+              <li key={t.id} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={task.dependencies.includes(t.id)}
+                  onChange={() => toggle(t.id)}
+                />
+                <span>{t.title}</span>
+              </li>
+            ))}
+        </ul>
+        <button
+          type="button"
+          onClick={onClose}
+          className="bg-gray-200 px-2 py-1 w-full"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/novaflow/src/features/tasks/components/TaskBoard.tsx
+++ b/novaflow/src/features/tasks/components/TaskBoard.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { useDeleteTask, useTasks } from '../hooks'
+import type { Task, TaskStatus } from '../types'
+
+const STATUSES: TaskStatus[] = ['todo', 'in-progress', 'done']
+
+export const TaskBoard: React.FC = () => {
+  const { data: tasks = [] } = useTasks()
+  const deleteTask = useDeleteTask()
+
+  const handleDelete = (id: string) => {
+    deleteTask.mutate(id, {
+      onError: (err: unknown) => alert((err as Error).message),
+    })
+  }
+
+  return (
+    <div className="flex gap-4">
+      {STATUSES.map((status) => (
+        <div key={status} className="flex-1">
+          <h3 className="font-bold capitalize">{status.replace('-', ' ')}</h3>
+          <ul className="space-y-2">
+            {tasks
+              .filter((t: Task) => t.status === status)
+              .map((task: Task) => (
+                <li key={task.id} className="border p-2 rounded">
+                  <div className="flex justify-between">
+                    <span>{task.title}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(task.id)}
+                      className="text-red-600"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </li>
+              ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/novaflow/src/features/tasks/components/TaskForm.tsx
+++ b/novaflow/src/features/tasks/components/TaskForm.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react'
+import { useCreateTask, useUpdateTask } from '../hooks'
+import type { Task, TaskInput, TaskStatus } from '../types'
+
+interface Props {
+  initial?: Task
+  onSuccess?: () => void
+}
+
+const defaultValues: TaskInput = {
+  title: '',
+  assignee: '',
+  status: 'todo',
+  priority: 'medium',
+  dueDate: '',
+  tags: [],
+}
+
+export const TaskForm: React.FC<Props> = ({ initial, onSuccess }) => {
+  const [form, setForm] = useState<TaskInput>(initial || defaultValues)
+  const createTask = useCreateTask()
+  const updateTask = useUpdateTask()
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => {
+    const { name, value } = e.target
+    if (name === 'tags') {
+      setForm({ ...form, tags: value.split(',').map((t) => t.trim()) })
+    } else {
+      setForm({ ...form, [name]: value })
+    }
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (initial) {
+      updateTask.mutate(
+        { id: initial.id, data: form },
+        { onSuccess },
+      )
+    } else {
+      createTask.mutate(form, { onSuccess })
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <input
+        name="title"
+        value={form.title}
+        onChange={handleChange}
+        placeholder="Title"
+        className="border p-1 w-full"
+      />
+      <input
+        name="assignee"
+        value={form.assignee}
+        onChange={handleChange}
+        placeholder="Assignee"
+        className="border p-1 w-full"
+      />
+      <select
+        name="status"
+        value={form.status}
+        onChange={handleChange}
+        className="border p-1 w-full"
+      >
+        {(['todo', 'in-progress', 'done'] as TaskStatus[]).map((s) => (
+          <option key={s} value={s}>
+            {s}
+          </option>
+        ))}
+      </select>
+      <select
+        name="priority"
+        value={form.priority}
+        onChange={handleChange}
+        className="border p-1 w-full"
+      >
+        {['low', 'medium', 'high'].map((p) => (
+          <option key={p} value={p}>
+            {p}
+          </option>
+        ))}
+      </select>
+      <input
+        type="date"
+        name="dueDate"
+        value={form.dueDate}
+        onChange={handleChange}
+        className="border p-1 w-full"
+      />
+      <input
+        name="tags"
+        value={form.tags?.join(', ')}
+        onChange={handleChange}
+        placeholder="Tags (comma separated)"
+        className="border p-1 w-full"
+      />
+      <button type="submit" className="bg-blue-500 text-white px-2 py-1">
+        {initial ? 'Update' : 'Create'}
+      </button>
+    </form>
+  )
+}

--- a/novaflow/src/features/tasks/hooks.ts
+++ b/novaflow/src/features/tasks/hooks.ts
@@ -1,0 +1,63 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+import * as api from './api'
+import type { TaskInput } from './types'
+
+export const useTasks = () =>
+  useQuery({ queryKey: ['tasks'], queryFn: api.listTasks })
+
+export const useCreateTask = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: api.createTask,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['tasks'] }),
+  })
+}
+
+export const useUpdateTask = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: TaskInput }) =>
+      api.updateTask(id, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['tasks'] }),
+  })
+}
+
+export const useDeleteTask = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: api.deleteTask,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['tasks'] }),
+  })
+}
+
+export const useAddDependency = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      taskId,
+      dependencyId,
+    }: {
+      taskId: string
+      dependencyId: string
+    }) => api.addDependency(taskId, dependencyId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['tasks'] }),
+  })
+}
+
+export const useRemoveDependency = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      taskId,
+      dependencyId,
+    }: {
+      taskId: string
+      dependencyId: string
+    }) => api.removeDependency(taskId, dependencyId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['tasks'] }),
+  })
+}

--- a/novaflow/src/features/tasks/index.ts
+++ b/novaflow/src/features/tasks/index.ts
@@ -1,0 +1,5 @@
+export * from './types'
+export * from './hooks'
+export { TaskBoard } from './components/TaskBoard'
+export { TaskForm } from './components/TaskForm'
+export { DependencyModal } from './components/DependencyModal'

--- a/novaflow/src/features/tasks/types.ts
+++ b/novaflow/src/features/tasks/types.ts
@@ -1,0 +1,21 @@
+export type TaskStatus = 'todo' | 'in-progress' | 'done'
+
+export interface Task {
+  id: string
+  title: string
+  assignee?: string
+  status: TaskStatus
+  priority: 'low' | 'medium' | 'high'
+  dueDate?: string
+  tags?: string[]
+  dependencies: string[]
+}
+
+export interface TaskInput {
+  title: string
+  assignee?: string
+  status: TaskStatus
+  priority: 'low' | 'medium' | 'high'
+  dueDate?: string
+  tags?: string[]
+}

--- a/novaflow/src/features/tasks/utils.ts
+++ b/novaflow/src/features/tasks/utils.ts
@@ -1,0 +1,22 @@
+import type { Task } from './types'
+
+/**
+ * Detects whether adding a dependency would create a circular reference.
+ */
+export function hasCircularDependency(
+  sourceId: string,
+  targetId: string,
+  tasks: Task[],
+): boolean {
+  const map = new Map<string, string[]>(tasks.map((t) => [t.id, t.dependencies]))
+  const visited = new Set<string>()
+
+  const visit = (id: string): boolean => {
+    if (id === sourceId) return true
+    if (visited.has(id)) return false
+    visited.add(id)
+    return (map.get(id) || []).some(visit)
+  }
+
+  return visit(targetId)
+}

--- a/novaflow/src/lib/index.ts
+++ b/novaflow/src/lib/index.ts
@@ -1,12 +1,16 @@
 // Utilities, constants, and permission logic
 
 // Permission utilities will be implemented here
+interface User {
+  role: string
+}
+
 export const permissions = {
-  canEditProject: (user: any, workspace: any) => {
-    return user.role === 'admin' || user.role === 'member';
+  canEditProject: (user: User) => {
+    return user.role === 'admin' || user.role === 'member'
   },
   // More permission functions will be added
-};
+}
 
 // Constants
 export const APP_CONSTANTS = {

--- a/novaflow/src/main.tsx
+++ b/novaflow/src/main.tsx
@@ -1,9 +1,14 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App'
+
+const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add React Query and provider
- implement task CRUD, kanban board, and dependency modal with circular validation
- warn before deleting tasks that other tasks depend on

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Cannot find module '@tanstack/react-query')*
- `pnpm install` *(fails: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fbacfc004832b9fde858c6b7d5348