### PR TITLE
feat: add project management components

### DIFF
--- a/novaflow/package.json
+++ b/novaflow/package.json
@@ -10,6 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@mantine/core": "^7.10.0",
+    "@mantine/form": "^7.10.0",
+    "@mantine/hooks": "^7.10.0",
+    "@supabase/supabase-js": "^2.45.0",
+    "@tanstack/react-query": "^5.51.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/novaflow/src/features/projects/ProjectCard.tsx
+++ b/novaflow/src/features/projects/ProjectCard.tsx
@@ -1,0 +1,62 @@
+import { Card, Group, Text, Button } from '@mantine/core';
+import { useState } from 'react';
+import type { Project, User } from '../../types';
+import { useDeleteProject } from './hooks';
+import { ProjectForm } from './ProjectForm';
+
+interface ProjectCardProps {
+  project: Project;
+  users: User[];
+  isAdmin: boolean;
+}
+
+export const ProjectCard = ({ project, users, isAdmin }: ProjectCardProps) => {
+  const [editing, setEditing] = useState(false);
+  const deleteMutation = useDeleteProject();
+
+  const handleDelete = () => {
+    const confirmed = window.confirm(
+      'Deleting a project will also delete all associated tasks. Continue?'
+    );
+    if (confirmed) {
+      deleteMutation.mutate({ id: project.id, workspace_id: project.workspace_id });
+    }
+  };
+
+  if (editing) {
+    return (
+      <Card shadow="sm" padding="lg" mt="sm">
+        <ProjectForm
+          project={project}
+          users={users}
+          isAdmin={isAdmin}
+          workspaceId={project.workspace_id}
+          onClose={() => setEditing(false)}
+        />
+      </Card>
+    );
+  }
+
+  return (
+    <Card shadow="sm" padding="lg" mt="sm">
+      <Group justify="space-between" align="flex-start">
+        <div>
+          <Text fw={500}>{project.title}</Text>
+          {project.description && (
+            <Text size="sm" c="dimmed">
+              {project.description}
+            </Text>
+          )}
+        </div>
+        <Group gap="xs">
+          <Button size="xs" variant="light" onClick={() => setEditing(true)}>
+            Edit
+          </Button>
+          <Button size="xs" color="red" variant="light" onClick={handleDelete}>
+            Delete
+          </Button>
+        </Group>
+      </Group>
+    </Card>
+  );
+};

--- a/novaflow/src/features/projects/ProjectForm.tsx
+++ b/novaflow/src/features/projects/ProjectForm.tsx
@@ -1,0 +1,64 @@
+import { Button, Group, Select, TextInput, Textarea } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import type { Project, User } from '../../types';
+import { useCreateProject, useUpdateProject } from './hooks';
+
+interface ProjectFormProps {
+  project?: Project;
+  users: User[];
+  isAdmin: boolean;
+  workspaceId: string;
+  onClose?: () => void;
+}
+
+export const ProjectForm = ({ project, users, isAdmin, workspaceId, onClose }: ProjectFormProps) => {
+  const form = useForm({
+    initialValues: {
+      title: project?.title || '',
+      description: project?.description || '',
+      owner_id: project?.owner_id || '',
+      status: project?.status || 'Todo',
+    },
+    validate: {
+      description: (value) =>
+        value && value.length > 500 ? 'Description must be 500 characters or less' : null,
+    },
+  });
+
+  const createMutation = useCreateProject();
+  const updateMutation = useUpdateProject();
+
+  const handleSubmit = form.onSubmit(async (values) => {
+    if (project) {
+      await updateMutation.mutateAsync({ ...project, ...values });
+    } else {
+      await createMutation.mutateAsync({ ...values, workspace_id: workspaceId });
+    }
+    onClose?.();
+  });
+
+  const ownerOptions = users.map((u) => ({ value: u.id, label: u.name }));
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <TextInput label="Title" required {...form.getInputProps('title')} />
+      <Textarea
+        label="Description"
+        mt="sm"
+        maxLength={500}
+        {...form.getInputProps('description')}
+      />
+      {isAdmin && (
+        <Select
+          label="Owner"
+          mt="sm"
+          data={ownerOptions}
+          {...form.getInputProps('owner_id')}
+        />
+      )}
+      <Group justify="flex-end" mt="md">
+        <Button type="submit">{project ? 'Update' : 'Create'}</Button>
+      </Group>
+    </form>
+  );
+};

--- a/novaflow/src/features/projects/ProjectsList.tsx
+++ b/novaflow/src/features/projects/ProjectsList.tsx
@@ -1,0 +1,39 @@
+import { Button, Loader, Stack } from '@mantine/core';
+import { useState } from 'react';
+import type { User } from '../../types';
+import { ProjectCard } from './ProjectCard';
+import { ProjectForm } from './ProjectForm';
+import { useProjects } from './hooks';
+
+interface ProjectsListProps {
+  workspaceId: string;
+  users: User[];
+  isAdmin: boolean;
+}
+
+export const ProjectsList = ({ workspaceId, users, isAdmin }: ProjectsListProps) => {
+  const { data, isLoading } = useProjects(workspaceId);
+  const [creating, setCreating] = useState(false);
+
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  return (
+    <Stack>
+      {data?.map((project) => (
+      <ProjectCard key={project.id} project={project} users={users} isAdmin={isAdmin} />
+      ))}
+      {creating ? (
+        <ProjectForm
+          users={users}
+          isAdmin={isAdmin}
+          workspaceId={workspaceId}
+          onClose={() => setCreating(false)}
+        />
+      ) : (
+        <Button onClick={() => setCreating(true)}>New Project</Button>
+      )}
+    </Stack>
+  );
+};

--- a/novaflow/src/features/projects/hooks.ts
+++ b/novaflow/src/features/projects/hooks.ts
@@ -1,0 +1,74 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '../../services/supabase';
+import type { Project } from '../../types';
+
+export const useProjects = (workspaceId: string) =>
+  useQuery({
+    queryKey: ['projects', workspaceId],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('projects')
+        .select('*')
+        .eq('workspace_id', workspaceId);
+      if (error) throw error;
+      return data as Project[];
+    },
+  });
+
+type ProjectInput = Omit<Project, 'id' | 'created_at'>;
+
+export const useCreateProject = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: ProjectInput) => {
+      const { data, error } = await supabase
+        .from('projects')
+        .insert(input)
+        .select()
+        .single();
+      if (error) throw error;
+      return data as Project;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['projects', data.workspace_id] });
+    },
+  });
+};
+
+export const useUpdateProject = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: Project) => {
+      const { data, error } = await supabase
+        .from('projects')
+        .update({
+          title: input.title,
+          description: input.description,
+          owner_id: input.owner_id,
+          status: input.status,
+        })
+        .eq('id', input.id)
+        .select()
+        .single();
+      if (error) throw error;
+      return data as Project;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['projects', data.workspace_id] });
+    },
+  });
+};
+
+export const useDeleteProject = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { id: string; workspace_id: string }) => {
+      const { error } = await supabase.from('projects').delete().eq('id', input.id);
+      if (error) throw error;
+      return input;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['projects', data.workspace_id] });
+    },
+  });
+};

--- a/novaflow/src/features/projects/index.ts
+++ b/novaflow/src/features/projects/index.ts
@@ -1,0 +1,9 @@
+export { ProjectsList } from './ProjectsList';
+export { ProjectCard } from './ProjectCard';
+export { ProjectForm } from './ProjectForm';
+export {
+  useProjects,
+  useCreateProject,
+  useUpdateProject,
+  useDeleteProject,
+} from './hooks';

--- a/novaflow/src/lib/index.ts
+++ b/novaflow/src/lib/index.ts
@@ -2,9 +2,8 @@
 
 // Permission utilities will be implemented here
 export const permissions = {
-  canEditProject: (user: any, workspace: any) => {
-    return user.role === 'admin' || user.role === 'member';
-  },
+  canEditProject: (user: { role?: string }) =>
+    user.role === 'admin' || user.role === 'member',
   // More permission functions will be added
 };
 

--- a/novaflow/src/services/index.ts
+++ b/novaflow/src/services/index.ts
@@ -1,7 +1,7 @@
 // API services and Supabase wrappers
 
-// Supabase client will be configured here
-// export { supabase } from './supabase';
+// Supabase client
+export { supabase } from './supabase';
 
 // Service abstractions will be implemented here
 export const apiService = {

--- a/novaflow/src/services/supabase.ts
+++ b/novaflow/src/services/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- add Supabase client and React Query hooks for projects
- implement project list, card, and form with admin-only owner select
- confirm cascade task deletion on project removal and limit description to 500 chars

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@mantine%2Fcore: Forbidden - 403)*
- `pnpm lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fbace66a4832b8693ec875e868e0b