### PR TITLE
Add simple routing and auth context scaffolding

### DIFF
--- a/novaflow/src/App.tsx
+++ b/novaflow/src/App.tsx
@@ -1,10 +1,18 @@
+import { LoginPage, AcceptInvitePage, ResetPasswordPage } from './features/auth';
+import { useRouter } from './lib/router';
+
 function App() {
-  return (
-    <div className="app">
-      <h1>NovaFlow</h1>
-      <p>Internal Collaboration Platform</p>
-    </div>
-  );
+  const { path } = useRouter();
+
+  switch (path) {
+    case '/accept-invite':
+      return <AcceptInvitePage />;
+    case '/reset-password':
+      return <ResetPasswordPage />;
+    case '/login':
+    default:
+      return <LoginPage />;
+  }
 }
 
-export default App; 
+export default App;

--- a/novaflow/src/context/AuthContext.tsx
+++ b/novaflow/src/context/AuthContext.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+interface AuthContextValue {
+  user: string | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<string | null>(null);
+
+  const login = async (email: string, password: string) => {
+    // Placeholder login implementation. Replace with Supabase auth logic.
+    void password;
+    setUser(email);
+  };
+
+  const logout = () => setUser(null);
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return ctx;
+}

--- a/novaflow/src/context/index.ts
+++ b/novaflow/src/context/index.ts
@@ -1,12 +1,12 @@
 // React context providers for global state
 
-// AuthContext will be implemented here
-// export { AuthProvider, useAuth } from './AuthContext';
+export { AuthProvider, useAuth } from './AuthContext';
 
-// NotificationContext will be implemented here  
+// NotificationContext will be implemented here
 // export { NotificationProvider, useNotification } from './NotificationContext';
 
 // Placeholder exports
 export const contextProviders = {
-  // Context providers will be exported here
+  AuthProvider,
+  // Additional context providers will be exported here
 };

--- a/novaflow/src/features/auth/AcceptInvitePage.tsx
+++ b/novaflow/src/features/auth/AcceptInvitePage.tsx
@@ -1,0 +1,14 @@
+import { Link } from '../../lib/router';
+
+function AcceptInvitePage() {
+  return (
+    <div>
+      <h2>Accept Invite</h2>
+      <nav>
+        <Link to="/login">Back to Login</Link>
+      </nav>
+    </div>
+  );
+}
+
+export default AcceptInvitePage;

--- a/novaflow/src/features/auth/LoginPage.tsx
+++ b/novaflow/src/features/auth/LoginPage.tsx
@@ -1,0 +1,16 @@
+import { Link } from '../../lib/router';
+
+function LoginPage() {
+  return (
+    <div>
+      <h2>Login</h2>
+      <nav>
+        <Link to="/reset-password">Reset Password</Link>
+        <br />
+        <Link to="/accept-invite">Accept Invite</Link>
+      </nav>
+    </div>
+  );
+}
+
+export default LoginPage;

--- a/novaflow/src/features/auth/ResetPasswordPage.tsx
+++ b/novaflow/src/features/auth/ResetPasswordPage.tsx
@@ -1,0 +1,14 @@
+import { Link } from '../../lib/router';
+
+function ResetPasswordPage() {
+  return (
+    <div>
+      <h2>Reset Password</h2>
+      <nav>
+        <Link to="/login">Back to Login</Link>
+      </nav>
+    </div>
+  );
+}
+
+export default ResetPasswordPage;

--- a/novaflow/src/features/auth/index.ts
+++ b/novaflow/src/features/auth/index.ts
@@ -1,0 +1,3 @@
+export { default as LoginPage } from './LoginPage';
+export { default as AcceptInvitePage } from './AcceptInvitePage';
+export { default as ResetPasswordPage } from './ResetPasswordPage';

--- a/novaflow/src/lib/router.tsx
+++ b/novaflow/src/lib/router.tsx
@@ -1,0 +1,53 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+interface RouterContextValue {
+  path: string;
+  navigate: (to: string) => void;
+}
+
+const RouterContext = createContext<RouterContextValue | undefined>(undefined);
+
+export function RouterProvider({ children }: { children: ReactNode }) {
+  const [path, setPath] = useState(() => window.location.pathname);
+
+  useEffect(() => {
+    const handlePopState = () => setPath(window.location.pathname);
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  const navigate = (to: string) => {
+    if (to !== path) {
+      window.history.pushState({}, '', to);
+      setPath(to);
+    }
+  };
+
+  return (
+    <RouterContext.Provider value={{ path, navigate }}>
+      {children}
+    </RouterContext.Provider>
+  );
+}
+
+export function useRouter() {
+  const ctx = useContext(RouterContext);
+  if (!ctx) {
+    throw new Error('useRouter must be used within RouterProvider');
+  }
+  return ctx;
+}
+
+export function Link({ to, children }: { to: string; children: ReactNode }) {
+  const { navigate } = useRouter();
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    navigate(to);
+  };
+  return (
+    <a href={to} onClick={handleClick}>
+      {children}
+    </a>
+  );
+}

--- a/novaflow/src/main.tsx
+++ b/novaflow/src/main.tsx
@@ -1,9 +1,15 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import { RouterProvider } from './lib/router';
+import { AuthProvider } from './context';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <RouterProvider>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </RouterProvider>
   </StrictMode>,
-)
+);


### PR DESCRIPTION
## Summary
- create minimal router, auth pages, and AuthContext provider
- wire up app with router provider and auth provider

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688fb461d580832b94fdf8f3ce9fae55